### PR TITLE
fix: parse POTA spotTime as UTC in SpotsTable

### DIFF
--- a/frontend/src/components/SpotsTable.tsx
+++ b/frontend/src/components/SpotsTable.tsx
@@ -1,5 +1,6 @@
 import type { AnnotatedSpot } from '../hooks/useSpots'
 import { freqKhzToBand } from '../utils/bandMap'
+import { formatSpotTimeUtc } from '../utils/spotTime'
 
 interface SpotsTableProps {
   spots: AnnotatedSpot[]
@@ -65,7 +66,7 @@ export function SpotsTable({ spots, onSelectSpot }: SpotsTableProps) {
                 <td style={{ ...td, color: '#cba6f7' }}>{band}</td>
                 <td style={{ ...td, color: '#94e2d5' }}>{spot.mode}</td>
                 <td style={{ ...td, color: '#a6adc8', fontSize: '0.78rem' }}>
-                  {new Date(spot.spotTime).toISOString().slice(11, 16)}Z
+                  {formatSpotTimeUtc(spot.spotTime)}Z
                 </td>
                 <td style={{ ...td, color: '#a6adc8', fontSize: '0.78rem', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {spot.comments}

--- a/frontend/src/utils/spotTime.test.ts
+++ b/frontend/src/utils/spotTime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatSpotTimeUtc } from './spotTime'
+
+describe('formatSpotTimeUtc', () => {
+  it('returns HH:MM UTC for ISO format without timezone marker', () => {
+    expect(formatSpotTimeUtc('2026-02-24T18:30:00')).toBe('18:30')
+  })
+
+  it('returns HH:MM UTC for space-separated format', () => {
+    expect(formatSpotTimeUtc('2026-02-24 18:30:00')).toBe('18:30')
+  })
+
+  it('does not shift time by local timezone offset', () => {
+    // 01:00 UTC should always display as 01:00, not shifted to local time
+    expect(formatSpotTimeUtc('2026-02-24T01:00:00')).toBe('01:00')
+  })
+
+  it('handles strings already marked as UTC with Z suffix', () => {
+    expect(formatSpotTimeUtc('2026-02-24T18:30:00Z')).toBe('18:30')
+  })
+})

--- a/frontend/src/utils/spotTime.ts
+++ b/frontend/src/utils/spotTime.ts
@@ -1,0 +1,14 @@
+/**
+ * Format a POTA API spotTime string as "HH:MM" in UTC.
+ *
+ * The POTA API returns spotTime in UTC but without a timezone suffix
+ * (e.g. "2026-02-24T18:30:00"). Without a suffix, JavaScript's Date
+ * constructor treats the string as local time, causing an incorrect UTC
+ * offset to be applied. Appending "Z" forces UTC interpretation.
+ */
+export function formatSpotTimeUtc(spotTime: string): string {
+  const utcStr = /Z$|[+-]\d{2}:\d{2}$/.test(spotTime)
+    ? spotTime
+    : spotTime.replace(' ', 'T') + 'Z'
+  return new Date(utcStr).toISOString().slice(11, 16)
+}


### PR DESCRIPTION
## Summary
- `new Date(spotTime)` was treating the POTA API's UTC timestamp string as local time because the string has no timezone suffix (e.g. `"2026-02-24T18:30:00"`)
- Calling `.toISOString()` then reconverted to UTC, shifting the displayed time by the user's local timezone offset
- Introduced `formatSpotTimeUtc()` in `src/utils/spotTime.ts` which appends `Z` before parsing to force UTC interpretation
- Updated `SpotsTable.tsx` to use the new utility

## Test plan
- [x] New unit tests in `src/utils/spotTime.test.ts` cover ISO format, space-separated format, pre-existing Z suffix, and a boundary `01:00` case
- [x] Tests run with `TZ=America/Denver` to verify timezone-sensitive correctness — all 33 tests pass
- [x] The old inline code `new Date(spotTime).toISOString().slice(11, 16)` produced `"01:30"` instead of `"18:30"` under Mountain Time; the fix produces the correct `"18:30"`

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)