### PR TITLE
fix: sort SpotsList by frequency, mode, then time

### DIFF
--- a/frontend/src/components/SpotsPanel.tsx
+++ b/frontend/src/components/SpotsPanel.tsx
@@ -3,6 +3,7 @@ import { SpotsFilter } from './SpotsFilter'
 import { SpotsTable } from './SpotsTable'
 import type { AnnotatedSpot } from '../hooks/useSpots'
 import { freqKhzToBand } from '../utils/bandMap'
+import { sortSpots } from '../utils/sortSpots'
 
 interface SpotsPanelProps {
   spots: AnnotatedSpot[]
@@ -16,11 +17,11 @@ export function SpotsPanel({ spots, loading, error, onSelectSpot, onRefresh }: S
   const [bandFilter, setBandFilter] = useState('')
   const [modeFilter, setModeFilter] = useState('')
 
-  const filtered = spots.filter(s => {
+  const filtered = sortSpots(spots.filter(s => {
     if (bandFilter && freqKhzToBand(parseFloat(s.frequency)) !== bandFilter) return false
     if (modeFilter && s.mode.toUpperCase() !== modeFilter.toUpperCase()) return false
     return true
-  })
+  }))
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>

--- a/frontend/src/utils/sortSpots.test.ts
+++ b/frontend/src/utils/sortSpots.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { sortSpots } from './sortSpots'
+import type { AnnotatedSpot } from '../hooks/useSpots'
+
+function makeSpot(frequency: string, mode: string, spotTime: string): AnnotatedSpot {
+  return {
+    spotId: 0,
+    activator: 'K1ABC',
+    name: 'Test Park',
+    reference: 'K-0001',
+    parkName: 'Test Park',
+    frequency,
+    mode,
+    source: 'test',
+    comments: '',
+    spotTime,
+    expire: 0,
+    hunted: false,
+  }
+}
+
+describe('sortSpots', () => {
+  it('sorts by frequency numerically ascending', () => {
+    const spots = [
+      makeSpot('14225.0', 'SSB', '2026-02-24T12:00:00'),
+      makeSpot('7035.0', 'CW', '2026-02-24T12:00:00'),
+      makeSpot('21310.0', 'SSB', '2026-02-24T12:00:00'),
+    ]
+    const result = sortSpots(spots)
+    expect(result.map(s => s.frequency)).toEqual(['7035.0', '14225.0', '21310.0'])
+  })
+
+  it('breaks frequency ties by mode ascending', () => {
+    const spots = [
+      makeSpot('14225.0', 'SSB', '2026-02-24T12:00:00'),
+      makeSpot('14225.0', 'CW', '2026-02-24T12:00:00'),
+      makeSpot('14225.0', 'FT8', '2026-02-24T12:00:00'),
+    ]
+    const result = sortSpots(spots)
+    expect(result.map(s => s.mode)).toEqual(['CW', 'FT8', 'SSB'])
+  })
+
+  it('breaks frequency+mode ties by time ascending', () => {
+    const spots = [
+      makeSpot('14225.0', 'SSB', '2026-02-24T14:00:00'),
+      makeSpot('14225.0', 'SSB', '2026-02-24T12:00:00'),
+      makeSpot('14225.0', 'SSB', '2026-02-24T13:00:00'),
+    ]
+    const result = sortSpots(spots)
+    expect(result.map(s => s.spotTime)).toEqual([
+      '2026-02-24T12:00:00',
+      '2026-02-24T13:00:00',
+      '2026-02-24T14:00:00',
+    ])
+  })
+
+  it('sorts numeric frequency correctly (not lexicographic)', () => {
+    // Lexicographic would put 9000 before 14000; numeric should not
+    const spots = [
+      makeSpot('14000.0', 'CW', '2026-02-24T12:00:00'),
+      makeSpot('9000.0', 'CW', '2026-02-24T12:00:00'),
+    ]
+    const result = sortSpots(spots)
+    expect(result.map(s => s.frequency)).toEqual(['9000.0', '14000.0'])
+  })
+})

--- a/frontend/src/utils/sortSpots.ts
+++ b/frontend/src/utils/sortSpots.ts
@@ -1,0 +1,13 @@
+import type { AnnotatedSpot } from '../hooks/useSpots'
+
+export function sortSpots(spots: AnnotatedSpot[]): AnnotatedSpot[] {
+  return [...spots].sort((a, b) => {
+    const freqDiff = parseFloat(a.frequency) - parseFloat(b.frequency)
+    if (freqDiff !== 0) return freqDiff
+
+    const modeCmp = a.mode.localeCompare(b.mode)
+    if (modeCmp !== 0) return modeCmp
+
+    return a.spotTime.localeCompare(b.spotTime)
+  })
+}


### PR DESCRIPTION
## Summary
- Extracts a `sortSpots` utility that sorts spots by frequency (numeric ascending), mode (alphabetical ascending), then spotTime (ascending)
- Applies `sortSpots` to the filtered spots in `SpotsPanel` before rendering
- Adds 4 unit tests covering numeric frequency sort, mode tiebreak, time tiebreak, and the lexicographic-vs-numeric edge case

## Root cause
The spots array was filtered but never sorted, so display order was arbitrary (API response order).

Fixes #2