### PR TITLE
Add Netlify deployment config with COOP/COEP headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+  base    = "frontend"
+  command = "npm run build"
+  publish = "dist"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy  = "same-origin"
+    Cross-Origin-Embedder-Policy = "require-corp"
+
+[[redirects]]
+  from   = "/*"
+  to     = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary
- Adds `netlify.toml` at the repo root to enable one-click Netlify deployment
- Sets `base = "frontend"` so Netlify runs the Vite build from the correct subdirectory
- Injects `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers on all responses — required for SQLite WASM to use OPFS in production
- Includes an SPA fallback redirect (`/* → /index.html`) as good practice

## Test plan
- [ ] Connect repo to Netlify and trigger a deploy — build log should show `npm run build` running from `frontend/`
- [ ] Deployed site loads and SQLite WASM initializes without errors in the browser console
- [ ] Browser DevTools → Network → verify `index.html` and `.wasm` responses include `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)