### PR TITLE
Show operator name inline with callsign label in QSO form

### DIFF
--- a/frontend/src/components/QsoForm.tsx
+++ b/frontend/src/components/QsoForm.tsx
@@ -4,6 +4,7 @@ import { generateUuid } from '../utils/uuid'
 import { freqMhzToBand, freqKhzToBand } from '../utils/bandMap'
 import { defaultRst } from '../utils/rstDefaults'
 import { useParkLookup } from '../hooks/useParkLookup'
+import { useCallsignLookup } from '../hooks/useCallsignLookup'
 import type { AnnotatedSpot } from '../hooks/useSpots'
 import type { HuntSession, Qso } from '../db/types'
 import { syncNewQso } from '../services/supabaseSync'
@@ -54,6 +55,7 @@ export function QsoForm({ session, selectedSpot, onQsoLogged }: QsoFormProps) {
   const [parkHistoryLoading, setParkHistoryLoading] = useState(false)
 
   const { park } = useParkLookup(form.parkReference)
+  const { user } = useCallsignLookup(form.callsign)
 
   // Look up previous QSOs for the callsign being entered
   useEffect(() => {
@@ -240,7 +242,10 @@ export function QsoForm({ session, selectedSpot, onQsoLogged }: QsoFormProps) {
         {/* Callsign column: input + callsign history below */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
           <div>
-            <label style={labelStyle}>Callsign *</label>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.4rem', marginBottom: 2 }}>
+              <label style={{ ...labelStyle, marginBottom: 0 }}>Callsign *</label>
+              {user && <span style={{ fontSize: '0.75rem', color: '#a6e3a1' }}>{user.name}</span>}
+            </div>
             <input
               style={{ ...inputStyle, textTransform: 'uppercase' }}
               value={form.callsign}

--- a/frontend/src/components/QsoForm.tsx
+++ b/frontend/src/components/QsoForm.tsx
@@ -244,12 +244,12 @@ export function QsoForm({ session, selectedSpot, onQsoLogged }: QsoFormProps) {
           <div>
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.4rem', marginBottom: 2 }}>
               <label style={{ ...labelStyle, marginBottom: 0 }}>Callsign *</label>
-              {user && <span style={{ fontSize: '0.75rem', color: '#a6e3a1' }}>{user.name}</span>}
+              {user?.name && <span style={{ fontSize: '0.75rem', color: '#a6e3a1' }}>{user.name}</span>}
             </div>
             <input
-              style={{ ...inputStyle, textTransform: 'uppercase' }}
+              style={inputStyle}
               value={form.callsign}
-              onChange={e => handleChange('callsign', e.target.value)}
+              onChange={e => handleChange('callsign', e.target.value.toUpperCase())}
               placeholder="W1AW"
             />
           </div>

--- a/frontend/src/hooks/useCallsignLookup.ts
+++ b/frontend/src/hooks/useCallsignLookup.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react'
+import { lookupUser, type PotaUser } from '../services/potaApi'
+
+export function useCallsignLookup(callsign: string): { user: PotaUser | null; loading: boolean } {
+  const [user, setUser] = useState<PotaUser | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const trimmed = callsign.trim().toUpperCase()
+    if (!trimmed) {
+      setUser(null)
+      return
+    }
+
+    setLoading(true)
+    const timer = setTimeout(async () => {
+      try {
+        const result = await lookupUser(trimmed)
+        setUser(result)
+      } catch {
+        setUser(null)
+      } finally {
+        setLoading(false)
+      }
+    }, 400)
+
+    return () => clearTimeout(timer)
+  }, [callsign])
+
+  return { user, loading }
+}

--- a/frontend/src/services/potaApi.ts
+++ b/frontend/src/services/potaApi.ts
@@ -33,3 +33,15 @@ export async function lookupPark(ref: string): Promise<PotaPark | null> {
   if (!resp.ok) throw new Error(`POTA park lookup failed: ${resp.status}`)
   return resp.json()
 }
+
+export interface PotaUser {
+  callsign: string
+  name: string
+}
+
+export async function lookupUser(callsign: string): Promise<PotaUser | null> {
+  const resp = await fetch(`${BASE}/stats/user/${encodeURIComponent(callsign)}`)
+  if (resp.status === 404) return null
+  if (!resp.ok) throw new Error(`POTA user lookup failed: ${resp.status}`)
+  return resp.json()
+}


### PR DESCRIPTION
## Summary
- Adds `lookupUser(callsign)` to `potaApi.ts` using the POTA `GET /stats/user/{callsign}` endpoint, which returns the operator's name
- Adds a new `useCallsignLookup` hook (mirrors `useParkLookup`) with 400ms debounce
- Displays the operator's name inline next to the "Callsign *" label in the QSO form, in green — identical pattern to how the park name appears next to the "Park *" label

## Test plan
- [ ] Type a valid POTA callsign (e.g. `W1AW`) into the Callsign field — operator name should appear inline after ~400ms
- [ ] Type an unknown/non-POTA callsign — no name should appear (graceful no-op)
- [ ] Select a spot from the spots panel — callsign prefills and name resolves automatically
- [ ] Submit a QSO — form clears and name disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)