### PR TITLE
Add flrig radio control via local CORS proxy

### DIFF
--- a/flrig-proxy.js
+++ b/flrig-proxy.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Tiny proxy that forwards XML-RPC to flrig and adds CORS + Private Network Access headers.
+// Usage: node flrig-proxy.js
+// Env vars: FLRIG_PROXY_PORT (default 12346), FLRIG_HOST (default localhost), FLRIG_PORT (default 12345)
+
+import http from 'node:http'
+
+const PROXY_PORT = parseInt(process.env.FLRIG_PROXY_PORT ?? '12346', 10)
+const FLRIG_HOST = process.env.FLRIG_HOST ?? 'localhost'
+const FLRIG_PORT = parseInt(process.env.FLRIG_PORT ?? '12345', 10)
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Private-Network': 'true',
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, CORS_HEADERS)
+    res.end()
+    return
+  }
+
+  const chunks = []
+  req.on('data', chunk => chunks.push(chunk))
+  req.on('end', () => {
+    const body = Buffer.concat(chunks)
+    const options = {
+      hostname: FLRIG_HOST,
+      port: FLRIG_PORT,
+      path: '/',
+      method: 'POST',
+      headers: { 'Content-Type': 'text/xml', 'Content-Length': body.length },
+    }
+    const proxy = http.request(options, upstream => {
+      const parts = []
+      upstream.on('data', d => parts.push(d))
+      upstream.on('end', () => {
+        res.writeHead(upstream.statusCode ?? 200, { ...CORS_HEADERS, 'Content-Type': 'text/xml' })
+        res.end(Buffer.concat(parts))
+      })
+    })
+    proxy.on('error', err => {
+      res.writeHead(502, CORS_HEADERS)
+      res.end(`flrig unreachable: ${err.message}`)
+    })
+    proxy.end(body)
+  })
+})
+
+server.listen(PROXY_PORT, () => {
+  console.log(`flrig proxy listening on :${PROXY_PORT} → ${FLRIG_HOST}:${FLRIG_PORT}`)
+})

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import type { AnnotatedSpot } from '../hooks/useSpots'
 import type { Qso, HuntSession } from '../db/types'
 import type { Settings } from '../hooks/useSettings'
 import { downloadAdif } from '../services/adifExport'
+import { setFrequency } from '../services/flrig'
 
 interface AppShellProps {
   session: HuntSession
@@ -91,7 +92,15 @@ export function AppShell({
             spots={spots}
             loading={spotsLoading}
             error={spotsError}
-            onSelectSpot={spot => setSelectedSpot(spot)}
+            onSelectSpot={spot => {
+              setSelectedSpot(spot)
+              if (settings.flrigEnabled && spot.frequency) {
+                const freqKhz = parseFloat(spot.frequency)
+                if (!isNaN(freqKhz)) {
+                  setFrequency(freqKhz, settings.flrigProxyPort).catch(() => {})
+                }
+              }
+            }}
             onRefresh={onRefreshSpots}
           />
         </div>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -26,6 +26,8 @@ export function SettingsPanel({ settings, onUpdate, onClose }: SettingsPanelProp
       operatorCallsign: form.operatorCallsign.trim().toUpperCase(),
       supabaseUrl: form.supabaseUrl.trim(),
       supabaseKey: form.supabaseKey.trim(),
+      flrigEnabled: form.flrigEnabled,
+      flrigProxyPort: form.flrigProxyPort,
     })
     onClose()
   }
@@ -69,6 +71,32 @@ export function SettingsPanel({ settings, onUpdate, onClose }: SettingsPanelProp
               onChange={e => setForm(f => ({ ...f, supabaseKey: e.target.value }))}
               placeholder="eyJ..."
             />
+          </div>
+          <div>
+            <label style={{ ...labelStyle, display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={form.flrigEnabled}
+                onChange={e => setForm(f => ({ ...f, flrigEnabled: e.target.checked }))}
+              />
+              Enable flrig radio control
+            </label>
+            {form.flrigEnabled && (
+              <div style={{ marginTop: '0.5rem' }}>
+                <label style={labelStyle}>Proxy port</label>
+                <input
+                  style={{ ...inputStyle, width: 100 }}
+                  type="number"
+                  value={form.flrigProxyPort}
+                  onChange={e => setForm(f => ({ ...f, flrigProxyPort: parseInt(e.target.value, 10) || 12346 }))}
+                  min={1024}
+                  max={65535}
+                />
+                <div style={{ marginTop: '0.3rem', color: '#6c7086', fontSize: '0.75rem' }}>
+                  Run <code>npm run flrig-proxy</code> from the project root
+                </div>
+              </div>
+            )}
           </div>
           <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
             <button

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -4,6 +4,8 @@ export interface Settings {
   operatorCallsign: string
   supabaseUrl: string
   supabaseKey: string
+  flrigEnabled: boolean
+  flrigProxyPort: number
 }
 
 const STORAGE_KEY = 'pota-logger-settings'
@@ -12,6 +14,8 @@ const DEFAULTS: Settings = {
   operatorCallsign: '',
   supabaseUrl: '',
   supabaseKey: '',
+  flrigEnabled: false,
+  flrigProxyPort: 12346,
 }
 
 function loadSettings(): Settings {

--- a/frontend/src/services/flrig.test.ts
+++ b/frontend/src/services/flrig.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setFrequency } from './flrig'
+
+describe('setFrequency', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response()))
+  })
+
+  it('sends a POST with <double> type for a whole-number kHz value', async () => {
+    await setFrequency(14074, 12346)
+
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('http://localhost:12346')
+    expect(init.method).toBe('POST')
+    expect(init.body).toContain('<double>14074000</double>')
+    expect(init.body).not.toContain('<int>')
+    expect(init.body).not.toContain('<i4>')
+  })
+
+  it('converts kHz to Hz correctly', async () => {
+    await setFrequency(7.074, 12346)
+
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(init.body).toContain('<double>7074</double>')
+  })
+
+  it('uses the provided proxy port', async () => {
+    await setFrequency(14074, 9999)
+
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('http://localhost:9999')
+  })
+
+  it('calls rig.set_vfo', async () => {
+    await setFrequency(14074, 12346)
+
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(init.body).toContain('<methodName>rig.set_vfo</methodName>')
+  })
+})

--- a/frontend/src/services/flrig.ts
+++ b/frontend/src/services/flrig.ts
@@ -1,0 +1,9 @@
+export async function setFrequency(freqKhz: number, proxyPort = 12346): Promise<void> {
+  const hz = freqKhz * 1000
+  const xml = `<?xml version="1.0"?><methodCall><methodName>rig.set_vfo</methodName><params><param><value><double>${hz}</double></value></param></params></methodCall>`
+  await fetch(`http://localhost:${proxyPort}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/xml' },
+    body: xml,
+  })
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  test: {
+    environment: 'node',
+  },
   plugins: [react()],
   server: {
     headers: {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pota-logger",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "flrig-proxy": "node flrig-proxy.js"
+  }
+}


### PR DESCRIPTION
## Summary
- Add \`flrig-proxy.js\`: a zero-dependency Node.js proxy that adds CORS and Private Network Access headers, forwarding XML-RPC calls to flrig running on \`localhost:12345\`
- Add root \`package.json\` with an \`npm run flrig-proxy\` convenience script
- Add \`frontend/src/services/flrig.ts\` with a \`setFrequency(freqKhz, proxyPort)\` helper that sends an XML-RPC \`rig.set_vfo\` call
- Extend \`Settings\` with \`flrigEnabled\`/\`flrigProxyPort\` fields; add flrig config section in SettingsPanel; wire \`setFrequency\` into \`AppShell\` spot selection (silent fail if proxy is not running)

## Test plan
- [ ] Start flrig on default port 12345
- [ ] Run \`npm run flrig-proxy\` from project root — should print \`flrig proxy listening on :12346 → localhost:12345\`
- [ ] Open app → Settings → check "Enable flrig radio control" → Save
- [ ] Click a spot in the left panel → radio should jump to that frequency
- [ ] Stop the proxy → click a spot → no error shown in the app (silent fail)
- [ ] Verify build: \`cd frontend && npm run build\` completes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)