### PR TITLE
Fix Netlify build: remove duplicate test config from vite.config.ts

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  test: {
-    environment: 'node',
-  },
   plugins: [react()],
   server: {
     headers: {


### PR DESCRIPTION
## Summary
- `vite.config.ts` had a redundant `test` block that caused a TypeScript error on Netlify (`TS2769: 'test' does not exist in type 'UserConfigExport'`)
- `vitest.config.ts` already exists and handles all Vitest configuration
- Removing the duplicate `test` block from `vite.config.ts` resolves the build failure

## Test plan
- [ ] Netlify deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)