### PR TITLE
Add QSO activity heatmap page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.97.0",
         "comlink": "^4.4.2",
         "react": "^18.3.1",
+        "react-activity-calendar": "^3.1.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -1171,6 +1172,31 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2774,6 +2800,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3998,6 +4034,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-activity-calendar": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-activity-calendar/-/react-activity-calendar-3.1.1.tgz",
+      "integrity": "sha512-YvHNS4anlW3Xy0fxOU2ZTWrJkOt0ALxX8IfgDRg6jr/vgYsbh//4djf2c7CPhYNROh+5oYZzR0EJaPbrFUj2tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.12",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-activity-calendar/node_modules/@floating-ui/react": {
+      "version": "0.27.18",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.18.tgz",
+      "integrity": "sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.7",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/react-activity-calendar/node_modules/@floating-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4248,6 +4325,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@supabase/supabase-js": "^2.97.0",
     "comlink": "^4.4.2",
     "react": "^18.3.1",
+    "react-activity-calendar": "^3.1.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/frontend/src/components/HeatmapPanel.tsx
+++ b/frontend/src/components/HeatmapPanel.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { ActivityCalendar } from 'react-activity-calendar'
+import { getDb } from '../db/db.client'
+
+type Activity = { date: string; count: number; level: 0 | 1 | 2 | 3 | 4 }
+
+function countToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count === 0) return 0
+  if (count <= 3) return 1
+  if (count <= 9) return 2
+  if (count <= 19) return 3
+  return 4
+}
+
+function buildActivityData(rows: { session_date: string; count: number }[]): Activity[] {
+  if (rows.length === 0) return []
+
+  const countByDate = new Map<string, number>()
+  for (const row of rows) {
+    countByDate.set(row.session_date, row.count)
+  }
+
+  const earliest = rows[0].session_date
+  const today = new Date().toISOString().slice(0, 10)
+
+  const activities: Activity[] = []
+  const cursor = new Date(earliest)
+  const end = new Date(today)
+
+  while (cursor <= end) {
+    const date = cursor.toISOString().slice(0, 10)
+    const count = countByDate.get(date) ?? 0
+    activities.push({ date, count, level: countToLevel(count) })
+    cursor.setDate(cursor.getDate() + 1)
+  }
+
+  return activities
+}
+
+export function HeatmapPanel() {
+  const [activities, setActivities] = useState<Activity[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getDb()
+      .then(db => db.getQsoCountsByDate())
+      .then(rows => setActivities(buildActivityData(rows)))
+      .catch(e => setError(String(e)))
+  }, [])
+
+  if (error) {
+    return <div style={{ color: '#f38ba8' }}>Error loading heatmap: {error}</div>
+  }
+
+  if (activities === null) {
+    return <div style={{ color: '#a6adc8' }}>Loading…</div>
+  }
+
+  if (activities.length === 0) {
+    return <div style={{ color: '#a6adc8' }}>No QSO history found.</div>
+  }
+
+  return (
+    <div>
+      <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>QSO Activity</h2>
+      <ActivityCalendar
+        data={activities}
+        theme={{
+          light: ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'],
+          dark: ['#161b22', '#9be9a8', '#40c463', '#30a14e', '#216e39'],
+        }}
+        colorScheme="dark"
+        showWeekdayLabels
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/HeatmapPanel.tsx
+++ b/frontend/src/components/HeatmapPanel.tsx
@@ -37,6 +37,21 @@ function buildActivityData(rows: { session_date: string; count: number }[]): Act
   return activities
 }
 
+function splitByYear(activities: Activity[]): [number, Activity[]][] {
+  const byYear = new Map<number, Activity[]>()
+  for (const a of activities) {
+    const year = parseInt(a.date.slice(0, 4))
+    if (!byYear.has(year)) byYear.set(year, [])
+    byYear.get(year)!.push(a)
+  }
+  return [...byYear.entries()].sort((a, b) => b[0] - a[0])
+}
+
+const THEME = {
+  light: ['#ebedf0', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
+  dark: ['#161b22', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
+}
+
 export function HeatmapPanel() {
   const [activities, setActivities] = useState<Activity[] | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -60,18 +75,25 @@ export function HeatmapPanel() {
     return <div style={{ color: '#a6adc8' }}>No QSO history found.</div>
   }
 
+  const years = splitByYear(activities)
+
   return (
     <div>
       <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>QSO Activity</h2>
-      <ActivityCalendar
-        data={activities}
-        theme={{
-          light: ['#ebedf0', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
-          dark: ['#161b22', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
-        }}
-        colorScheme="dark"
-        showWeekdayLabels
-      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+        {years.map(([year, data]) => (
+          <div key={year}>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: '#a6adc8' }}>{year}</div>
+            <ActivityCalendar
+              data={data}
+              theme={THEME}
+              colorScheme="dark"
+              showWeekdayLabels
+              showMonthLabels
+            />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/HeatmapPanel.tsx
+++ b/frontend/src/components/HeatmapPanel.tsx
@@ -66,8 +66,8 @@ export function HeatmapPanel() {
       <ActivityCalendar
         data={activities}
         theme={{
-          light: ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'],
-          dark: ['#161b22', '#9be9a8', '#40c463', '#30a14e', '#216e39'],
+          light: ['#ebedf0', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
+          dark: ['#161b22', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
         }}
         colorScheme="dark"
         showWeekdayLabels

--- a/frontend/src/db/db.worker.ts
+++ b/frontend/src/db/db.worker.ts
@@ -116,6 +116,17 @@ export class DbWorker {
     return rows.map(r => r.park_reference)
   }
 
+  async getQsoCountsByDate(): Promise<{ session_date: string; count: number }[]> {
+    return db.selectObjects(
+      `SELECT hs.session_date, COUNT(q.id) as count
+       FROM hunt_sessions hs
+       LEFT JOIN qsos q ON q.hunt_session_id = hs.id
+       GROUP BY hs.session_date
+       ORDER BY hs.session_date`,
+      []
+    ) as { session_date: string; count: number }[]
+  }
+
   async upsertQsosFromRemote(sessions: HuntSession[], qsos: Omit<Qso, 'synced'>[]): Promise<void> {
     db.exec('BEGIN')
     try {


### PR DESCRIPTION
## Summary
- Adds a new Heatmap tab to the app with a GitHub-style activity calendar showing QSO history by date
- Adds `getQsoCountsByDate()` to `DbWorker` — joins `hunt_sessions` + `qsos`, groups by date
- Creates `HeatmapPanel.tsx` using `react-activity-calendar`; fills date gaps, maps counts to 5 intensity levels, fetches lazily on mount
- Updates `AppShell.tsx` with Log/Heatmap nav buttons and conditional rendering so each view only mounts when active

## Test plan
- [ ] Click "Heatmap" tab — component mounts, shows loading state, then renders calendar
- [ ] Days with QSOs show green squares at appropriate intensity (1–3/4–9/10–19/20+)
- [ ] Click "Log" tab — returns to normal two-column log view
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)