### PR TITLE
Add new parks hunted heatmap side by side with QSO activity

### DIFF
--- a/frontend/src/components/HeatmapPanel.tsx
+++ b/frontend/src/components/HeatmapPanel.tsx
@@ -80,7 +80,7 @@ const THEME = {
   dark: ['#161b22', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
 }
 
-function YearlyCalendar({ activities }: { activities: Activity[] }) {
+function YearlyCalendar({ activities, totalCountLabel }: { activities: Activity[], totalCountLabel: string }) {
   const years = splitByYear(activities)
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
@@ -93,6 +93,7 @@ function YearlyCalendar({ activities }: { activities: Activity[] }) {
             colorScheme="dark"
             showWeekdayLabels
             showMonthLabels
+            labels={{ totalCount: `{{count}} ${totalCountLabel}` }}
           />
         </div>
       ))}
@@ -123,19 +124,19 @@ export function HeatmapPanel() {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '3rem' }}>
+    <div style={{ display: 'flex', flexDirection: 'row', gap: '3rem', alignItems: 'flex-start' }}>
       <section>
         <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>QSO Activity</h2>
         {qsoActivities.length === 0
           ? <div style={{ color: '#a6adc8' }}>No QSO history found.</div>
-          : <YearlyCalendar activities={qsoActivities} />}
+          : <YearlyCalendar activities={qsoActivities} totalCountLabel="QSOs" />}
       </section>
 
       <section>
         <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>New Parks Hunted</h2>
         {newParkActivities.length === 0
           ? <div style={{ color: '#a6adc8' }}>No park history found.</div>
-          : <YearlyCalendar activities={newParkActivities} />}
+          : <YearlyCalendar activities={newParkActivities} totalCountLabel="New Parks" />}
       </section>
     </div>
   )

--- a/frontend/src/components/HeatmapPanel.tsx
+++ b/frontend/src/components/HeatmapPanel.tsx
@@ -4,7 +4,7 @@ import { getDb } from '../db/db.client'
 
 type Activity = { date: string; count: number; level: 0 | 1 | 2 | 3 | 4 }
 
-function countToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+function qsoCountToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
   if (count === 0) return 0
   if (count <= 3) return 1
   if (count <= 9) return 2
@@ -12,7 +12,18 @@ function countToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
   return 4
 }
 
-function buildActivityData(rows: { session_date: string; count: number }[]): Activity[] {
+function newParkCountToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count === 0) return 0
+  if (count === 1) return 1
+  if (count === 2) return 2
+  if (count === 3) return 3
+  return 4
+}
+
+function buildActivityData(
+  rows: { session_date: string; count: number }[],
+  toLevel: (count: number) => 0 | 1 | 2 | 3 | 4
+): Activity[] {
   if (rows.length === 0) return []
 
   const countByDate = new Map<string, number>()
@@ -30,7 +41,7 @@ function buildActivityData(rows: { session_date: string; count: number }[]): Act
   while (cursor <= end) {
     const date = cursor.toISOString().slice(0, 10)
     const count = countByDate.get(date) ?? 0
-    activities.push({ date, count, level: countToLevel(count) })
+    activities.push({ date, count, level: toLevel(count) })
     cursor.setDate(cursor.getDate() + 1)
   }
 
@@ -69,48 +80,63 @@ const THEME = {
   dark: ['#161b22', '#216e39', '#30a14e', '#40c463', '#9be9a8'],
 }
 
+function YearlyCalendar({ activities }: { activities: Activity[] }) {
+  const years = splitByYear(activities)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      {years.map(([year, data]) => (
+        <div key={year}>
+          <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: '#a6adc8' }}>{year}</div>
+          <ActivityCalendar
+            data={data}
+            theme={THEME}
+            colorScheme="dark"
+            showWeekdayLabels
+            showMonthLabels
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function HeatmapPanel() {
-  const [activities, setActivities] = useState<Activity[] | null>(null)
+  const [qsoActivities, setQsoActivities] = useState<Activity[] | null>(null)
+  const [newParkActivities, setNewParkActivities] = useState<Activity[] | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    getDb()
-      .then(db => db.getQsoCountsByDate())
-      .then(rows => setActivities(buildActivityData(rows)))
-      .catch(e => setError(String(e)))
+    getDb().then(db =>
+      Promise.all([db.getQsoCountsByDate(), db.getNewParkCountsByDate()])
+    ).then(([qsoRows, parkRows]) => {
+      setQsoActivities(buildActivityData(qsoRows, qsoCountToLevel))
+      setNewParkActivities(buildActivityData(parkRows, newParkCountToLevel))
+    }).catch(e => setError(String(e)))
   }, [])
 
   if (error) {
     return <div style={{ color: '#f38ba8' }}>Error loading heatmap: {error}</div>
   }
 
-  if (activities === null) {
+  if (qsoActivities === null || newParkActivities === null) {
     return <div style={{ color: '#a6adc8' }}>Loading…</div>
   }
 
-  if (activities.length === 0) {
-    return <div style={{ color: '#a6adc8' }}>No QSO history found.</div>
-  }
-
-  const years = splitByYear(activities)
-
   return (
-    <div>
-      <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>QSO Activity</h2>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-        {years.map(([year, data]) => (
-          <div key={year}>
-            <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: '#a6adc8' }}>{year}</div>
-            <ActivityCalendar
-              data={data}
-              theme={THEME}
-              colorScheme="dark"
-              showWeekdayLabels
-              showMonthLabels
-            />
-          </div>
-        ))}
-      </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '3rem' }}>
+      <section>
+        <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>QSO Activity</h2>
+        {qsoActivities.length === 0
+          ? <div style={{ color: '#a6adc8' }}>No QSO history found.</div>
+          : <YearlyCalendar activities={qsoActivities} />}
+      </section>
+
+      <section>
+        <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.1rem', color: '#cba6f7' }}>New Parks Hunted</h2>
+        {newParkActivities.length === 0
+          ? <div style={{ color: '#a6adc8' }}>No park history found.</div>
+          : <YearlyCalendar activities={newParkActivities} />}
+      </section>
     </div>
   )
 }

--- a/frontend/src/db/db.worker.ts
+++ b/frontend/src/db/db.worker.ts
@@ -127,6 +127,22 @@ export class DbWorker {
     ) as { session_date: string; count: number }[]
   }
 
+  async getNewParkCountsByDate(): Promise<{ session_date: string; count: number }[]> {
+    return db.selectObjects(
+      `SELECT first_date as session_date, COUNT(*) as count
+       FROM (
+         SELECT q.park_reference, MIN(hs.session_date) as first_date
+         FROM qsos q
+         JOIN hunt_sessions hs ON q.hunt_session_id = hs.id
+         WHERE q.park_reference IS NOT NULL
+         GROUP BY q.park_reference
+       )
+       GROUP BY first_date
+       ORDER BY first_date`,
+      []
+    ) as { session_date: string; count: number }[]
+  }
+
   async upsertQsosFromRemote(sessions: HuntSession[], qsos: Omit<Qso, 'synced'>[]): Promise<void> {
     db.exec('BEGIN')
     try {


### PR DESCRIPTION
## Summary
- Adds `getNewParkCountsByDate()` to `DbWorker` — finds the first date each park was hunted (subquery), then counts debuts per day
- Renders a second "New Parks Hunted" heatmap alongside QSO Activity, displayed side by side
- Uses tighter level thresholds for new parks (1/2/3/4+) since counts are smaller than raw QSOs
- Bottom-of-calendar label customized: "X QSOs" for the first, "X New Parks" for the second

## Test plan
- [ ] Heatmap tab shows two calendars side by side: QSO Activity (left) and New Parks Hunted (right)
- [ ] New Parks calendar only lights up on days a park was hunted for the first time
- [ ] Count labels at bottom of each year read "X QSOs" / "X New Parks"
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)