### PR TITLE
Persist spot filters across page switches and reorder table columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,62 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this repository.
 
 ## Project
 
-This is a POTA (Parks on the Air) logger application with a frontend-first development approach.
+POTA (Parks on the Air) logger — a frontend-first web app for logging amateur radio contacts while activating or hunting parks.
 
-<!-- Update this file as the project develops with build commands, architecture details, and conventions. -->
+## Stack
+
+- React 18 + TypeScript + Vite 5 in `frontend/`
+- SQLite WASM (`@sqlite.org/sqlite-wasm`) with opfs-sahpool VFS for in-browser persistent storage
+- Comlink 4 (raw — `vite-plugin-comlink` was dropped due to a source-map crash in prod builds)
+- Supabase JS v2 for optional background sync to the cloud
+- Node 20.20.0 / npm 10.8.2
+
+## Commands
+
+```bash
+cd frontend && npm run dev      # dev server (requires OPFS-capable browser)
+cd frontend && npm run build    # production build
+cd frontend && npm test         # run all tests
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/App.tsx` | Top-level data wiring (session, QSOs, spots) |
+| `frontend/src/components/AppShell.tsx` | Main layout, page navigation (log / heatmap), filter state |
+| `frontend/src/components/SpotsPanel.tsx` | Spot list with band/mode filtering |
+| `frontend/src/components/SpotsTable.tsx` | Spot table (Band, Mode, Freq, ★, Park, Activator, Time, Comments) |
+| `frontend/src/components/QsoTable.tsx` | QSO table (Time, Band, Mode, Freq, Callsign, RST S/R, Park) |
+| `frontend/src/components/HeatmapPanel.tsx` | Activity heatmaps (QSO activity + new parks hunted) |
+| `frontend/src/db/db.worker.ts` | `DbWorker` class — all SQLite access, exposed via Comlink |
+| `frontend/src/db/db.client.ts` | `getDb()` singleton returning `Remote<DbWorker>` |
+| `frontend/src/db/queries.ts` | Named SQL constants for heatmap queries |
+| `frontend/src/db/schema.sql.ts` | SQLite schema — single source of truth |
+| `frontend/src/hooks/useSettings.ts` | Persistent settings via localStorage (callsign, Supabase creds, flrig) |
+
+## Architecture Notes
+
+- **SQLite worker**: `DbWorker` runs in a Web Worker via Comlink. `db.worker.ts` calls `Comlink.expose(new DbWorker())`. Client code calls `getDb()` and awaits methods on the returned proxy.
+- **No routing library**: Navigation between log/heatmap pages is a simple `activePage` state in `AppShell`. Filter state (band/mode) lives in `AppShell` so it persists across page switches.
+- **COOP/COEP headers**: Set in `vite.config.ts` for dev, and in `netlify.toml` for production — required for SharedArrayBuffer / OPFS.
+
+## Supabase Sync
+
+- Credentials entered via Settings UI and stored in localStorage — no `.env` file needed.
+- Migration SQL: `supabase/migration.sql` — run once in the Supabase SQL Editor.
+- Sync upserts sessions before QSOs to satisfy the foreign key constraint.
+
+## Deployment
+
+- Hosted on Netlify. Config in `netlify.toml` at repo root (`base = "frontend"`, `publish = "dist"`).
+- No environment variables needed — Supabase credentials are entered by the user in the app.
+
+## Testing
+
+- Vitest with jsdom (global default) and `// @vitest-environment node` for Node-specific tests.
+- SQL query logic tested with `better-sqlite3` in-memory DB — see `frontend/src/db/parkCountsByDate.test.ts`.
+- Schema imported from `schema.sql.ts` in tests to stay in sync with production.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steven Burns
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# POTA Hunt Logger
+
+A browser-based logging app for [Parks on the Air (POTA)](https://parksontheair.com/) hunters. Log QSOs, browse live spots, and track your park history — all stored locally in your browser with optional cloud sync.
+
+## Features
+
+- **Live spots** — fetches active POTA spots with band/mode filtering
+- **QSO logging** — log contacts with auto-fill from selected spots
+- **Local-first storage** — all data stored in SQLite in your browser (no account required)
+- **Activity heatmaps** — visualise your QSO activity and new parks hunted over time
+- **Supabase sync** — optional background sync to the cloud for backup and multi-device access
+- **ADIF export** — export your log for upload to POTA, QRZ, LoTW, etc.
+- **flrig integration** — optional radio control via a local CORS proxy
+
+## Tech Stack
+
+- React 18 + TypeScript + Vite
+- SQLite WASM (in-browser, persistent via OPFS)
+- Supabase JS v2 (optional sync)
+
+## Usage
+
+The app is deployed at: **[your Netlify URL here]**
+
+No installation or account required. Open the app, enter your callsign in Settings, and start logging.
+
+### Settings
+
+| Setting | Description |
+|---------|-------------|
+| Callsign | Your amateur radio callsign |
+| Supabase URL + key | Optional — enables cloud sync and backup |
+| flrig proxy port | Optional — enables radio frequency control |
+
+## Running Locally
+
+```bash
+git clone https://github.com/stevenmburns/claude-frontend-first-pota-logger.git
+cd claude-frontend-first-pota-logger/frontend
+npm install
+npm run dev
+```
+
+Requires a Chromium-based browser (Chrome, Edge, Arc) for OPFS storage support.
+
+## Development
+
+```bash
+npm run dev      # dev server at http://localhost:5173
+npm run build    # production build
+npm test         # run tests
+```
+
+See [CLAUDE.md](CLAUDE.md) for architecture notes and codebase conventions.
+
+## License
+
+MIT

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -30,6 +30,8 @@ export function AppShell({
 }: AppShellProps) {
   const [activePage, setActivePage] = useState<'log' | 'heatmap'>('log')
   const [selectedSpot, setSelectedSpot] = useState<AnnotatedSpot | null>(null)
+  const [bandFilter, setBandFilter] = useState('')
+  const [modeFilter, setModeFilter] = useState('')
   const [showSettings, setShowSettings] = useState(false)
   const [splitPct, setSplitPct] = useState(66.7)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -113,6 +115,10 @@ export function AppShell({
               spots={spots}
               loading={spotsLoading}
               error={spotsError}
+              bandFilter={bandFilter}
+              modeFilter={modeFilter}
+              onBandFilterChange={setBandFilter}
+              onModeFilterChange={setModeFilter}
               onSelectSpot={spot => {
                 setSelectedSpot(spot)
                 if (settings.flrigEnabled && spot.frequency) {

--- a/frontend/src/components/QsoTable.tsx
+++ b/frontend/src/components/QsoTable.tsx
@@ -37,12 +37,12 @@ export function QsoTable({ qsos, onDeleted }: QsoTableProps) {
         <thead>
           <tr>
             <th style={th}>Time (UTC)</th>
-            <th style={th}>Callsign</th>
-            <th style={th}>Park</th>
-            <th style={th}>Freq</th>
             <th style={th}>Band</th>
             <th style={th}>Mode</th>
+            <th style={th}>Freq</th>
+            <th style={th}>Callsign</th>
             <th style={th}>RST S/R</th>
+            <th style={th}>Park</th>
             <th style={th}></th>
           </tr>
         </thead>
@@ -50,12 +50,12 @@ export function QsoTable({ qsos, onDeleted }: QsoTableProps) {
           {qsos.map(q => (
             <tr key={q.id}>
               <td style={{ ...td, color: '#a6adc8' }}>{utcTime(q.timestamp)}</td>
-              <td style={{ ...td, color: '#89b4fa', fontWeight: 600 }}>{q.callsign}</td>
-              <td style={{ ...td }}>{q.park_reference}</td>
-              <td style={{ ...td, color: '#f9e2af' }}>{q.frequency}</td>
               <td style={{ ...td, color: '#cba6f7' }}>{q.band}</td>
               <td style={{ ...td, color: '#94e2d5' }}>{q.mode}</td>
+              <td style={{ ...td, color: '#f9e2af' }}>{q.frequency}</td>
+              <td style={{ ...td, color: '#89b4fa', fontWeight: 600 }}>{q.callsign}</td>
               <td style={{ ...td }}>{q.rst_sent}/{q.rst_received}</td>
+              <td style={{ ...td }}>{q.park_reference}</td>
               <td style={{ ...td }}>
                 <button
                   onClick={() => handleDelete(q.id)}

--- a/frontend/src/components/SpotsPanel.tsx
+++ b/frontend/src/components/SpotsPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { SpotsFilter } from './SpotsFilter'
 import { SpotsTable } from './SpotsTable'
 import type { AnnotatedSpot } from '../hooks/useSpots'
@@ -11,11 +10,13 @@ interface SpotsPanelProps {
   error: Error | null
   onSelectSpot: (spot: AnnotatedSpot) => void
   onRefresh: () => void
+  bandFilter: string
+  modeFilter: string
+  onBandFilterChange: (v: string) => void
+  onModeFilterChange: (v: string) => void
 }
 
-export function SpotsPanel({ spots, loading, error, onSelectSpot, onRefresh }: SpotsPanelProps) {
-  const [bandFilter, setBandFilter] = useState('')
-  const [modeFilter, setModeFilter] = useState('')
+export function SpotsPanel({ spots, loading, error, onSelectSpot, onRefresh, bandFilter, modeFilter, onBandFilterChange, onModeFilterChange }: SpotsPanelProps) {
 
   const filtered = sortSpots(spots.filter(s => {
     if (bandFilter && freqKhzToBand(parseFloat(s.frequency)) !== bandFilter) return false
@@ -28,7 +29,7 @@ export function SpotsPanel({ spots, loading, error, onSelectSpot, onRefresh }: S
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 0.5rem' }}>
         <SpotsFilter
           band={bandFilter} mode={modeFilter}
-          onBandChange={setBandFilter} onModeChange={setModeFilter}
+          onBandChange={onBandFilterChange} onModeChange={onModeFilterChange}
         />
         <button
           onClick={onRefresh}

--- a/frontend/src/components/SpotsTable.tsx
+++ b/frontend/src/components/SpotsTable.tsx
@@ -27,12 +27,12 @@ export function SpotsTable({ spots, onSelectSpot }: SpotsTableProps) {
       <table style={{ width: '100%', borderCollapse: 'collapse' }}>
         <thead>
           <tr>
-            <th style={th}>Activator</th>
-            <th style={{ ...th, width: '1.2rem', padding: '0.4rem 0.2rem' }}></th>
-            <th style={th}>Park</th>
-            <th style={th}>Freq</th>
             <th style={th}>Band</th>
             <th style={th}>Mode</th>
+            <th style={th}>Freq</th>
+            <th style={{ ...th, width: '1.2rem', padding: '0.4rem 0.2rem' }}></th>
+            <th style={th}>Park</th>
+            <th style={th}>Activator</th>
             <th style={th}>Time (UTC)</th>
             <th style={th}>Comments</th>
           </tr>
@@ -54,9 +54,9 @@ export function SpotsTable({ spots, onSelectSpot }: SpotsTableProps) {
                   (e.currentTarget as HTMLElement).style.background = rowBg ?? ''
                 }}
               >
-                <td style={{ ...td, color: spot.hunted ? '#a6e3a1' : '#89b4fa', fontWeight: 600 }}>
-                  {spot.hunted ? '✓ ' : ''}{spot.activator}
-                </td>
+                <td style={{ ...td, color: '#cba6f7' }}>{band}</td>
+                <td style={{ ...td, color: '#94e2d5' }}>{spot.mode}</td>
+                <td style={{ ...td, color: '#f9e2af' }}>{spot.frequency}</td>
                 <td style={{ ...td, padding: '0.35rem 0.2rem', textAlign: 'center', color: '#f9e2af' }}>
                   {spot.newPark && !spot.hunted ? '★' : ''}
                 </td>
@@ -68,9 +68,9 @@ export function SpotsTable({ spots, onSelectSpot }: SpotsTableProps) {
                     {spot.parkName}
                   </span>
                 </td>
-                <td style={{ ...td, color: '#f9e2af' }}>{spot.frequency}</td>
-                <td style={{ ...td, color: '#cba6f7' }}>{band}</td>
-                <td style={{ ...td, color: '#94e2d5' }}>{spot.mode}</td>
+                <td style={{ ...td, color: spot.hunted ? '#a6e3a1' : '#89b4fa', fontWeight: 600 }}>
+                  {spot.hunted ? '✓ ' : ''}{spot.activator}
+                </td>
                 <td style={{ ...td, color: '#a6adc8', fontSize: '0.78rem' }}>
                   {formatSpotTimeUtc(spot.spotTime)}
                 </td>


### PR DESCRIPTION
## Summary
- Lift `bandFilter`/`modeFilter` state from `SpotsPanel` into `AppShell` so filter selections survive navigating to the heatmap page and back
- Reorder `SpotsTable` columns to: Band, Mode, Freq, ★, Park, Activator, Time (UTC), Comments
- Reorder `QsoTable` columns to: Time (UTC), Band, Mode, Freq, Callsign, RST S/R, Park

## Test plan
- [ ] Set a band/mode filter on the spots list, switch to Heatmap, switch back — filters should be retained
- [ ] Verify SpotsTable column order matches: Band, Mode, Freq, ★, Park, Activator, Time, Comments
- [ ] Verify QsoTable column order matches: Time, Band, Mode, Freq, Callsign, RST S/R, Park

🤖 Generated with [Claude Code](https://claude.com/claude-code)